### PR TITLE
Fix Branding & Typographical Errors

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -21,7 +21,7 @@ Below is a list of actions and frameworks we'd love to see open-source contribut
 - [ ] Pond model integrations
 
 ## NFT & Digital Assets
-- [ ] Integrations with OpenSeas
+- [ ] Integrations with OpenSea
 - [ ] MagicEden create collection
 - [ ] Generate image, deploy NFT collection E2E
 

--- a/python/create-onchain-agent/CHANGELOG.md
+++ b/python/create-onchain-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added wallet persistance to all templates (#484)
+- Added wallet persistence to all templates (#484)
 
 ### Fixed
 


### PR DESCRIPTION
Branding Correction
Changed: "Integrations with OpenSeas" → "Integrations with OpenSea"
Reason:
"OpenSeas" is incorrect and does not correspond to any known blockchain marketplace.
"OpenSea" is the correct and official name of the NFT marketplace.
Using the correct name ensures brand accuracy and avoids confusion for users.
Typographical Fix
Changed: "Added wallet persistance to all templates (#484)" → "Added wallet persistence to all templates (#484)"
Reason:
"Persistance" is a misspelling of the correct English word "persistence."
Correct spelling improves readability and ensures documentation professionalism.
Consistent terminology prevents misunderstandings and maintains high-quality project documentation.